### PR TITLE
Segment.intersection test incomplete?

### DIFF
--- a/src/segment.ml
+++ b/src/segment.ml
@@ -63,14 +63,22 @@ let intersects ((a1, b1 as s1):t) ((a2,b2 as s2):t) =
   | Line.Error Line.Parallel(_) -> false
 
 let intersection ((a1, b1 as s1):t) ((a2,b2 as s2):t) =
+  let approx_lt eps n1 n2 =
+    n1 < n2 &&
+    (Float.abs n2 -. n1)  > eps
+  in
   let open Point in
   try
     let p = Line.intersection (to_line s1) (to_line s2)
     and sqd = sq_distance a1 b1 
     and sqd2 = sq_distance a2 b2 in
-    if sq_distance a1 p < sqd && sq_distance b1 p < sqd &&
-       sq_distance a2 p < sqd2 && sq_distance b2 p < sqd2
-    then Some p else None
+    let eps = 1.0E-8 in
+      let ale = approx_lt eps in
+      if ale (sq_distance a1 p) sqd &&
+         ale (sq_distance b1 p) sqd &&
+         ale (sq_distance a2 p) sqd2 &&
+         ale (sq_distance b2 p) sqd2 
+      then Some p else None
   with
   | Line.Error Line.Parallel(_) -> None
 

--- a/src/segment.ml
+++ b/src/segment.ml
@@ -51,21 +51,25 @@ let proj_y ((a,b):t) =
   if a.y > b.y then b.y,a.y
   else a.y,b.y
 
-let intersects ((a1, b1 as s1):t) (s2:t) =
+let intersects ((a1, b1 as s1):t) ((a2,b2 as s2):t) =
   let open Point in
   try
     let p = Line.intersection (to_line s1) (to_line s2)
-    and sqd = sq_distance a1 b1 in
-    sq_distance a1 p <= sqd && sq_distance b1 p <= sqd
+    and sqd = sq_distance a1 b1 
+    and sqd2 = sq_distance a2 b2 in
+    sq_distance a1 p <= sqd && sq_distance b1 p <= sqd &&
+    sq_distance a2 p <= sqd2 && sq_distance b2 p <= sqd2
   with
   | Line.Error Line.Parallel(_) -> false
 
-let intersection ((a1, b1 as s1):t) (s2:t) =
+let intersection ((a1, b1 as s1):t) ((a2,b2 as s2):t) =
   let open Point in
   try
     let p = Line.intersection (to_line s1) (to_line s2)
-    and sqd = sq_distance a1 b1 in
-    if sq_distance a1 p < sqd && sq_distance b1 p < sqd
+    and sqd = sq_distance a1 b1 
+    and sqd2 = sq_distance a2 b2 in
+    if sq_distance a1 p < sqd && sq_distance b1 p < sqd &&
+       sq_distance a2 p < sqd2 && sq_distance b2 p < sqd2
     then Some p else None
   with
   | Line.Error Line.Parallel(_) -> None
@@ -75,7 +79,7 @@ let intersect_line (((p1,p2) as s):t) l =
   try
     let p = Line.intersection l (to_line s)
     and sqd = sq_distance p1 p2 in
-    if sq_distance p1 p <= sqd && sq_distance p2 p <= sqd
+    if sq_distance p1 p <= sqd && sq_distance p2 p <= sqd 
     then Some p else None
   with
   | Line.Error Line.Parallel(_) -> None


### PR DESCRIPTION
While solving Euler-project problem 165 I used geoml.  It seems to me that the code in Segment.intersection is incomplete, as it only checks that the intersection is within (a1,b1).  It should also check that p is between (a2,b2).  Same applies to Segment.intersects.

I assume it is not an oversight, that Segment.intersects and Segment.intersection have different criteria ('<' vs '<='), since Segment.intersection returns *true* intersections (a1,b1) whereas Segment.intersects also returns true if the intersection is one of the end-points [a1,b1].